### PR TITLE
Avoid "Internal error" when no url are given

### DIFF
--- a/src/mercury-parser.js
+++ b/src/mercury-parser.js
@@ -3,6 +3,15 @@ import Mercury from '@postlight/mercury-parser';
 import { corsSuccessResponse, corsErrorResponse, runWarm } from './utils';
 
 const mercuryParser = async ({ queryStringParameters }, context, cb) => {
+  if (!queryStringParameters) {
+    return cb(
+      null,
+      corsErrorResponse({
+        message: 'Provide an URL in the query string: ?url=',
+      })
+    );
+  }
+
   const { url } = queryStringParameters;
 
   const result = await Mercury.parse(url);


### PR DESCRIPTION
Instead provide a clear message to the user on how the parser should be used.
